### PR TITLE
Fix bad edge case in bubble sort

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -1110,7 +1110,7 @@ Interpreter.prototype.initArray = function(scope) {
           "changes++;",
         "}",
       "}",
-      "if (changes <= 1) break;",
+      "if (!changes) break;",
     "}",
     "return this;",
   "}",


### PR DESCRIPTION
Turns out the `Array.prototype.sort` polyfill, implemented as a bubble sort, is broken.

Brought to our attention [by a Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/115548) and [easily reproduced in App Lab](https://studio.code.org/projects/applab/EhvVsXgunaoKzICxPwLVQA/view) with the following code:
```js
// Array.sort doesn't work properly
console.log([5, 4, 5, 1].sort());
// Expected: [1,4,5,5]
// Actual  : [4,1,5,5]
```

The problem is that this `Array.prototype.sort` polyfill, which uses a bubble sort, is implemented incorrectly:

https://github.com/code-dot-org/JS-Interpreter/blob/37933e4c4cc26eac31fb77a42ab20931db9a1e13/interpreter.js#L1100-L1117

The exact issue is the `if (changes <= 1) break;` line.  Stepping through the algorithm for the broken case, we can see that we're breaking too early, when only one swap has occurred in the pass but there's still more work to do.

```
i is 0
  begin 5,4,5,1
  j is 0
    swap 5 and 4
  j is 1
  j is 2
    swap 5 and 1
  end 4,5,1,5
i is 1
  begin 4,5,1,5
  j is 0
  j is 1
    swap 5 and 1
  end 4,1,5,5
[4,1,5,5]
```

The solution is to check `changes < 1` or just `!changes`.  [That's what's happened upstream](https://github.com/NeilFraser/JS-Interpreter/blob/e113e87a1ff75c08b9334f957166e994b4ff18c3/interpreter.js#L1030) in addition to some other optimizations we should eventually grab, but for now I want a very targeted bugfix.