### PR TITLE
Fix for 'TypeError: undefined is not a function'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "1d:60:b6:10:ea:05:35:ef:20:b6:ad:a6:2f:b1:20:89"
+            - "52:2b:1c:c1:1e:54:a3:e1:f5:f9:a5:65:aa:d9:b7:db"
       - checkout
       - restore_cache:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
     # this is for the circle 1.0 API
     parallelism: 10
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "1d:60:b6:10:ea:05:35:ef:20:b6:ad:a6:2f:b1:20:89"
       - checkout
       - restore_cache:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,6 @@ jobs:
     # this is for the circle 1.0 API
     parallelism: 10
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "52:2b:1c:c1:1e:54:a3:e1:f5:f9:a5:65:aa:d9:b7:db"
       - checkout
       - restore_cache:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}

--- a/interpreter.js
+++ b/interpreter.js
@@ -2773,22 +2773,22 @@ Interpreter.prototype['stepCallExpression'] = function() {
   if (state.doneCallee_ === 1) {
     // Determine value of the function.
     state.doneCallee_ = 2;
-    var func = state.value;
-    if (Array.isArray(func)) {
-      state.func_ = this.getValue(func);
-      state.components_ = func;
-      func = state.func_;
-      if (typeof func === 'object' && func.isGetter) {
+    var stateValue = state.value;
+    if (Array.isArray(stateValue)) {
+      state.func_ = this.getValue(stateValue);
+      state.components_ = stateValue;
+      var stateFunc = state.func_;
+      if (typeof stateFunc === 'object' && stateFunc.isGetter) {
         // Clear the getter flag and call the getter function.
-        func.isGetter = false;
-        this.pushGetter_(/** @type {!Interpreter.Object} */ (func),
+        stateFunc.isGetter = false;
+        this.pushGetter_(/** @type {!Interpreter.Object} */ (stateFunc),
                          state.value);
         state.doneCallee_ = 1;
         return;
       }
     } else {
       // Already evaluated function: (function(){...})();
-      state.func_ = func;
+      state.func_ = stateValue;
     }
     state.arguments_ = [];
     state.n_ = 0;
@@ -2808,6 +2808,10 @@ Interpreter.prototype['stepCallExpression'] = function() {
     state.doneExec_ = true;
     var func = state.func_;
     if (!func || !func.isObject) {
+      var components = state.components_;
+      if (components && Array.isArray(components) && 1 <= components.length) {
+        func = node['callee'].object.name + '.' + components[1];
+      }
       this.throwException(this.TYPE_ERROR, func + ' is not a function');
     }
     // Determine value of 'this' in function.

--- a/interpreter.js
+++ b/interpreter.js
@@ -1922,19 +1922,31 @@ Interpreter.prototype.pseudoToNative = function(pseudoObj, opt_cycles) {
 };
 
 /**
- * Constructs the fully qualified name of a child node. i.e. baz->foo.bar.baz.
+ * Constructs the fully qualified name of a child node
+ * example: baz->foo.bar.baz
+ * example: bar->foo[0].bar
  * @param {node} object The child node of the object call stack
- * @return {string} The string representation of the object call stack.
+ * @return {string} The fully qualified name of the child node.
  */
 Interpreter.prototype.getFullyQualifiedName = function(node) {
-  var objectCallStack = [];
+  var fullyQualifiedName = '';
   while (node.object && node.property) {
-    objectCallStack.push(node.property.name);
+    var properties = node.property;
+    // 'computed' is a flag in acorn that indicates square brackets were used
+    if (node.computed) {
+      var name = properties.name ? properties.name : properties.raw;
+      fullyQualifiedName = '[' + name + ']' + fullyQualifiedName;
+    } else {
+      fullyQualifiedName = '.' + properties.name + fullyQualifiedName;
+    }
     node = node.object;
   }
-  var fullyQualifiedName = node.name;
-  while (0 < objectCallStack.length) {
-    fullyQualifiedName += '.' + objectCallStack.pop();
+  // Re-construct the highest-level parent node
+  if ("ArrayExpression" == node.type) {
+    // Handle case of [0].foo()
+    fullyQualifiedName = "Array" + fullyQualifiedName;
+  } else {
+    fullyQualifiedName = node.name + fullyQualifiedName;
   }
   return fullyQualifiedName;
 };

--- a/interpreter.js
+++ b/interpreter.js
@@ -2807,12 +2807,24 @@ Interpreter.prototype['stepCallExpression'] = function() {
   if (!state.doneExec_) {
     state.doneExec_ = true;
     var func = state.func_;
-    if (!func || !func.isObject) {
+    var isNotFunction = ' is not a function';
+    if (!func) {
+      var callee = node['callee'];
       var components = state.components_;
-      if (components && Array.isArray(components) && 1 <= components.length) {
-        func = node['callee'].object.name + '.' + components[1];
+      var functionName;
+      if (callee.object) {
+        functionName = callee.object.name;
+        if (components && Array.isArray(components) && 1 <= components.length) {
+          functionName += '.' + components[1];
+        }
       }
-      this.throwException(this.TYPE_ERROR, func + ' is not a function');
+      else {
+        functionName = callee.name;
+      }
+      this.throwException(this.TYPE_ERROR, functionName + isNotFunction);
+    }
+    if (!func.isObject) {
+      this.throwException(this.TYPE_ERROR, func + isNotFunction);
     }
     // Determine value of 'this' in function.
     if (state.node['type'] === 'NewExpression') {

--- a/interpreter.js
+++ b/interpreter.js
@@ -2803,22 +2803,22 @@ Interpreter.prototype['stepCallExpression'] = function() {
   if (state.doneCallee_ === 1) {
     // Determine value of the function.
     state.doneCallee_ = 2;
-    var functionComponents = state.value;
-    if (Array.isArray(functionComponents)) {
-      state.func_ = this.getValue(functionComponents);
-      state.components_ = functionComponents;
-      var stateFunc = state.func_;
-      if (typeof stateFunc === 'object' && stateFunc.isGetter) {
+    var func = state.value;
+    if (Array.isArray(func)) {
+      state.func_ = this.getValue(func);
+      state.components_ = func;
+      func = state.func_;
+      if (typeof func === 'object' && func.isGetter) {
         // Clear the getter flag and call the getter function.
-        stateFunc.isGetter = false;
-        this.pushGetter_(/** @type {!Interpreter.Object} */ (stateFunc),
+        func.isGetter = false;
+        this.pushGetter_(/** @type {!Interpreter.Object} */ (func),
                          state.value);
         state.doneCallee_ = 1;
         return;
       }
     } else {
       // Already evaluated function: (function(){...})();
-      state.func_ = functionComponents;
+      state.func_ = func;
     }
     state.arguments_ = [];
     state.n_ = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/js-interpreter",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Code.org fork of NeilFraser/JS-Interpreter for use within Code Studio learning environment.",
   "main": "interpreter.js",
   "repository": {


### PR DESCRIPTION
Fix for 'TypeError: undefined is not a function' when an undefined function call is invoked for a class.

Now, instead of 'undefined' the interpreter will print class.function

Example:
foo = {};
foo.bar();
=> [old output] TypeError: undefined is not a function
=> [new output] TypeError: foo.bar is not a function