### PR TITLE
Improve error messaging for accessing properties of undefined objects

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -3556,6 +3556,12 @@ Interpreter.prototype['stepMemberExpression'] = function() {
     if (state.components) {
       stack[stack.length - 1].value = [state.object_, state.value];
     } else {
+      if (state.object_ == this.NULL || state.object_ == this.UNDEFINED)
+      {
+        var name = this.getFullyQualifiedName(node.object);
+        this.throwException(this.TYPE_ERROR, name + " is not defined.");
+        return;
+      }
       var value = this.getProperty(state.object_, state.value);
       if (!value) {
         stack.push({});

--- a/interpreter.js
+++ b/interpreter.js
@@ -3559,7 +3559,8 @@ Interpreter.prototype['stepMemberExpression'] = function() {
       if (state.object_ == this.NULL || state.object_ == this.UNDEFINED)
       {
         var name = this.getFullyQualifiedName(node.object);
-        this.throwException(this.TYPE_ERROR, name + " is not defined.");
+        this.throwException(this.TYPE_ERROR, name + " is " +
+            state.object_.toString());
         return;
       }
       var value = this.getProperty(state.object_, state.value);


### PR DESCRIPTION
Before: "Cannot read property _propertyName_ of undefined"
After: "_objectName_ is undefined"