### PR TITLE
Added static function that will read a string of code and return the AST

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -147,6 +147,16 @@ Interpreter.READONLY_NONENUMERABLE_DESCRIPTOR = {
 Interpreter.toStringCycles_ = [];
 
 /**
+ * Creates an abstract syntax tree from a string of code
+ * @param {string} code - Raw JavaScript text
+ * @param {object} parseOptions - Configuration for acorn parser
+ * @returns {object} the AST for the given code
+ */
+Interpreter.generateAST = function(code, parseOptions) {
+  return acorn.parse(code, {...Interpreter.PARSE_OPTIONS, ...parseOptions});
+};
+
+/**
  * Add more code to the interpreter.
  * @param {string|!Object} code Raw JavaScript text or AST.
  */

--- a/interpreter.js
+++ b/interpreter.js
@@ -153,7 +153,11 @@ Interpreter.toStringCycles_ = [];
  * @returns {object} the AST for the given code
  */
 Interpreter.generateAST = function(code, parseOptions) {
-  return acorn.parse(code, {...Interpreter.PARSE_OPTIONS, ...parseOptions});
+  var options = Interpreter.PARSE_OPTIONS;
+  Object.keys(parseOptions).forEach(function(key) {
+    options[key] = parseOptions[key];
+  });
+  return acorn.parse(code, options);
 };
 
 /**


### PR DESCRIPTION
This will allow us to parse student code for publishing student libraries. See this PR in the code-dot-org repo for more details: https://github.com/code-dot-org/code-dot-org/pull/30853

NOTE: v1.3.10 is the branch we are currently publishing to for the 1.3.10 release. Master is not currently the latest branch. This same PR is being made to master here: https://github.com/code-dot-org/JS-Interpreter/pull/33