### PR TITLE
Avoid recursion within step

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -170,30 +170,31 @@ Interpreter.prototype.appendCode = function(code) {
  * @return {boolean} True if a step was executed, false if no more instructions.
  */
 Interpreter.prototype.step = function() {
-  var stack = this.stateStack;
-  var state = stack[stack.length - 1];
-  if (!state) {
-    return false;
-  }
-  var node = state.node, type = node['type'];
-  if (type === 'Program' && state.done) {
-    return false;
-  } else if (this.paused_) {
-    return true;
-  }
-  try {
-    this.functionMap_[type]();
-  } catch (e) {
-    // Eat any step errors.  They have been thrown on the stack.
-    if (e !== Interpreter.STEP_ERROR) {
-      // Uh oh.  This is a real error in the JS-Interpreter.  Rethrow.
-      throw e;
+  var node;
+  do {
+    var stack = this.stateStack;
+    var state = stack[stack.length - 1];
+    if (!state) {
+      return false;
     }
-  }
-  if (!node['end']) {
-    // This is polyfill code.  Keep executing until we arrive at user code.
-    return this.step();
-  }
+    var node = state.node, type = node['type'];
+    if (type === 'Program' && state.done) {
+      return false;
+    } else if (this.paused_) {
+      return true;
+    }
+    try {
+      this.functionMap_[type]();
+    } catch (e) {
+      // Eat any step errors.  They have been thrown on the stack.
+      if (e !== Interpreter.STEP_ERROR) {
+        // Uh oh.  This is a real error in the JS-Interpreter.  Rethrow.
+        throw e;
+      }
+    }
+    // When node['end'] is missing, we are in polyfill code.
+    // Keep executing until we arrive at user code.
+  } while (!node['end']);
   return true;
 };
 

--- a/interpreter.js
+++ b/interpreter.js
@@ -177,7 +177,8 @@ Interpreter.prototype.step = function() {
     if (!state) {
       return false;
     }
-    var node = state.node, type = node['type'];
+    node = state.node;
+    var type = node['type'];
     if (type === 'Program' && state.done) {
       return false;
     } else if (this.paused_) {


### PR DESCRIPTION
- A simple program running in the interpreter can easily hit a `Maximum call stack size exceeded` exception if it invokes "polyfill" code (e.g. `Array.sort()`). This issue has been present in the interpreter for several years.
- Fix this issue by avoiding recursion within `step()`. Instead, we loop through the step logic to achieve the same effect.