### PR TITLE
Updated readme to explain our new release branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ https://neil.fraser.name/software/JS-Interpreter/
 
 Documentation:
 https://neil.fraser.name/software/JS-Interpreter/docs.html
+
+NPM packages are published from the `release` branch. `master` is currently preserving a set of breaking changes that may eventually be released.


### PR DESCRIPTION
We now publish from the `release` branch due to a set of breaking changes that live in the master branch and were never published.