### PR TITLE
Fix switch statements

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -3752,8 +3752,8 @@ Interpreter.prototype['stepSwitchStatement'] = function() {
       continue;
     }
     if (switchCase) {
-      if (!state.matched_ && !stack.tested_ && switchCase['test']) {
-        stack.tested_ = true;
+      if (!state.matched_ && !state.tested_ && switchCase['test']) {
+        state.tested_ = true;
         stack.push({node: switchCase['test']});
         return;
       }
@@ -3768,7 +3768,7 @@ Interpreter.prototype['stepSwitchStatement'] = function() {
         }
       }
       // Move on to next case.
-      stack.tested_ = false;
+      state.tested_ = false;
       state.n_ = 0;
       state.index_ = index + 1;
     } else {


### PR DESCRIPTION
Pulls in commit `3241706` ([original commit](https://github.com/NeilFraser/JS-Interpreter/commit/3241706)) from upstream which fixes repeated switch statements. Looks like what was going wrong was storing the internal state on the stack itself when it should have been specific to each stack _frame_.

Before:
![image](https://user-images.githubusercontent.com/8787187/78405923-652a7380-75b6-11ea-8c4f-c22ecc714de1.png)

After:
![image](https://user-images.githubusercontent.com/8787187/78405897-56dc5780-75b6-11ea-9bfd-d535c45dd18c.png)
